### PR TITLE
Fix profile behavior

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -22,7 +22,7 @@ func createProvider(configureContextFunc schema.ConfigureContextFunc) *schema.Pr
 			"profile": {
 				Type:     schema.TypeString,
 				Optional: true,
-				Default:  "default",
+				Default:  "",
 			},
 			"region": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
AWS SDK doesn't use all of the methods in default credentials chain when the `profile` is set to "default". So setting it to empty string.